### PR TITLE
Fix visualizations for years with minimal data

### DIFF
--- a/scripts/color_palettes.R
+++ b/scripts/color_palettes.R
@@ -102,13 +102,19 @@ get_zsr_palette <- function(palette_type, palette_name, n = NULL, reverse = FALS
       }
       # Handle case where n exceeds palette max
       palette_info <- RColorBrewer::brewer.pal.info[palette_spec, ]
-      if (n > palette_info$maxcolors) {
+      max_colors <- palette_info$maxcolors
+
+      # RColorBrewer requires minimum 3 colors for most palettes
+      # Get the palette-specific minimum from the actual function
+      min_colors <- if (palette_info$category == "qual") 3 else 3
+
+      if (n > max_colors) {
         # Interpolate for more colors
-        base_colors <- RColorBrewer::brewer.pal(palette_info$maxcolors, palette_spec)
+        base_colors <- RColorBrewer::brewer.pal(max_colors, palette_spec)
         grDevices::colorRampPalette(base_colors)(n)
-      } else if (n < palette_info$mincolors) {
+      } else if (n < min_colors) {
         # Get minimum and subset
-        RColorBrewer::brewer.pal(palette_info$mincolors, palette_spec)[1:n]
+        RColorBrewer::brewer.pal(min_colors, palette_spec)[1:n]
       } else {
         RColorBrewer::brewer.pal(n, palette_spec)
       }

--- a/scripts/plot_functions.R
+++ b/scripts/plot_functions.R
@@ -501,13 +501,16 @@ plot_books_table <- function(df_library, df_dailies, year, config, color_mapping
       column_labels.font.size = gt::px(9),
       data_row.padding = gt::px(4),
       heading.padding = gt::px(0)
-    ) %>%
-
-    # Subtle alternating row colors
-    gt::tab_style(
-      style = gt::cell_fill(color = "gray97"),
-      locations = gt::cells_body(rows = seq(2, nrow(df), 2))
     )
+
+  # Add subtle alternating row colors (only if more than 1 row)
+  if (nrow(df) > 1) {
+    table <- table %>%
+      gt::tab_style(
+        style = gt::cell_fill(color = "gray97"),
+        locations = gt::cells_body(rows = seq(2, nrow(df), 2))
+      )
+  }
 
   return(table)
 }


### PR DESCRIPTION
Two bugs prevented charts from rendering when a year has only 1 book or 1 reading session:

1. Color palette: ColorBrewer Set2 requires minimum 3 colors, but code failed when requesting n=1. Now properly subsets the minimum.

2. Books table: Alternating row styling used seq(2, nrow, 2) which creates empty sequence when nrow=1, causing gt table error. Now only applies alternating rows when nrow > 1.

Tested with 2026 data (1 book, 1 session): heatmap, overlay, table, and session distribution all work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)